### PR TITLE
Initial steps to define application ack.

### DIFF
--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -498,7 +498,7 @@ None
 
 == Communicate Device-Patient Association [DEV-51]
 
-Insert in Section 3 of IHE TF Vol 2 as new Section 3.51
+Insert in Section 3 of IHE PCD TF Vol 2 as new Section 3.51
 
 === Scope
 
@@ -580,7 +580,7 @@ If the checks are passed, the Manager establishes a record of the beginning or e
 
 == Report Device-Patient Association [DEV-52]
 
-Insert in Section 3 of IHE TF Vol 2 as new Section 3.52
+Insert in Section 3 of IHE PCD TF Vol 2 as new Section 3.52
 
 === Scope
 
@@ -663,7 +663,7 @@ If a commit-level acknowledgement is received by the Manager, it logs the messag
 
 == 3.19 Filter Device-Patient Associations [DEV-19]
 
-Insert in Section 3 of IHE TF Vol 2 as new Section 3.19
+Insert in Section 3 of IHE PCD TF Vol 2 as new Section 3.19
 
 === Scope
 
@@ -850,7 +850,7 @@ Table A.1.2.1-1: MSH Fields
 | 16
 | ID
 | R
-| Application Acknowledgement Type – Set to AL, NE or ER. See IHE TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
+| Application Acknowledgement Type – Set to AL, NE or ER. See IHE PCD TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
 
 | 21
 | EI

--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -1319,6 +1319,33 @@ ICCBBA DIs: 2.16.840.1.113883.6.18.1.17 for Blood containers and 2.16.840.1.1138
 
 Example: |00643169001763{caret}{caret}2.51.1.1{caret}ISO|
 
+=== A.1.3 Application ACK Message
+
+Table A.1.3-1: Communicate Device-Patient Association - Application Acknowledgement Message
+
+|===
+| *Segments* | *Description* | *Usage*
+
+| MSH
+| Message Header - Defined in Appendix B.1
+| R
+
+| MSA
+| Message Acknowledgement - Defined in Appendix B.2
+| R
+
+| [{ ERR }]
+| Error - Defined in Appendix B.3.
+| C
+
+| [{ SFT }]
+| Software
+| X
+
+| [{ NTE }]
+| Notes and Comments
+| X
+
 == A.2 Device-Patient Association Query Message
 
 === A.2.1 Scope

--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -1346,6 +1346,8 @@ Table A.1.3-1: Communicate Device-Patient Association - Application Acknowledgem
 | Notes and Comments
 | X
 
+|===
+
 == A.2 Device-Patient Association Query Message
 
 === A.2.1 Scope

--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -498,7 +498,7 @@ None
 
 == Communicate Device-Patient Association [DEV-51]
 
-Insert in Section 3 as new Section 3.51
+Insert in Section 3 of IHE TF Vol 2 as new Section 3.51
 
 === Scope
 
@@ -574,13 +574,13 @@ On receipt of the message, the manager system checks for valid syntax and that t
 . the device is a member of the set of registered device instances and has no current conflicting association recorded (e.g., a single-patient device has an active association with a different patient)
 . the patient identity provided corresponds to a known person in an appropriate status (e.g., admitted)
 
-After these checks, the Manager logs the result and returns an appropriate positive or negative acknowledgement to the Reporter. The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document.
+After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. An optional application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager.  The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
 
 If the checks are passed, the Manager establishes a record of the beginning or ending of the association and the effective time.
 
 == Report Device-Patient Association [DEV-52]
 
-Insert in Section 3 as new Section 3.52
+Insert in Section 3 of IHE TF Vol 2 as new Section 3.52
 
 === Scope
 
@@ -662,6 +662,8 @@ If the checks are passed, the Consumer utilizes the record of the beginning or e
 If a commit-level acknowledgement is received by the Manager, it logs the message as delivered successfully to the Consumer.
 
 == 3.19 Filter Device-Patient Associations [DEV-19]
+
+Insert in Section 3 of IHE TF Vol 2 as new Section 3.19
 
 === Scope
 
@@ -833,7 +835,29 @@ MSH, SFT, and UAC Segments: follow the specifications for [PCD-01] in PCD TF-2 A
 
 ==== A.1.2.1 MSH -- Message Header
 
-Since this message is effectively an unsolicited observation report, the contents of the MSH segment follow the specifications for [PCD-01] in PCD TF-2 Appendix B.1, except that MSH-21 is valued "IHE_DEV_051^IHE PCD\^1.3.6.1.4.1.19376.1.6.4.51.1^ISO" to identify it as a message representing a device-patient association.
+Since this message is effectively an unsolicited observation report, the contents of the MSH segment follow the specifications for [PCD-01] in PCD TF-2 Appendix B.1, except for the following changes:
+
+Table A.1.2.1-1: MSH Fields
+
+|===
+| *SEQ* | *DT* | *OPT*  | *Description*
+
+| 15
+| ID
+| R
+| Accept Acknowledgement Type - This must be set to "AL" and is returned on the same connection as the initiating message.
+
+| 16
+| ID
+| R
+| Application Acknowledgement Type – Set to AL, NE or ER. See IHE TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
+
+| 21
+| EI
+| R
+| Message Profile Identifier - Value set to "IHE_DEV_051^IHE PCD\^1.3.6.1.4.1.19376.1.6.4.51.1^ISO"
+
+|===
 
 ==== A.1.2.2 PID -- Patient Identification
 

--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -1423,7 +1423,7 @@ Table A.2.3-2: QBP{caret}Z66{caret}QBP{caret}QBP_Z66 Query Grammar - QBP Message
 | 5.5.6
 |===
 
-An ACK is expected as response to this query, see the definition of the ORU{caret}R01 Message Structure in PCD TF-2
+A simple commit-level ACK is expected as response to this query, see section B.2 in IHE PCD TF VOL 2.
 
 The results of a successful query results in the manager sending all [DEV-52] messages reporting current device-patient association events followed by ongoing real-time updates to device-patient association events, all filtered according to optional query parameters. If the connection is lost, the manager must continue to try and establish a new connection to the consumer, always sending the current device-patient association events matching the filter once the connection is re-established.
 

--- a/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
+++ b/CPs/IHE_DEV_Suppl_PCIM_Foundational CP applied.adoc
@@ -574,7 +574,7 @@ On receipt of the message, the manager system checks for valid syntax and that t
 . the device is a member of the set of registered device instances and has no current conflicting association recorded (e.g., a single-patient device has an active association with a different patient)
 . the patient identity provided corresponds to a known person in an appropriate status (e.g., admitted)
 
-After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. An optional application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager.  The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
+After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. If a positive commit-level acknowledgement is sent, an application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager (Additional detail on  application acknowledgement semantics is forthcoming). The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
 
 If the checks are passed, the Manager establishes a record of the beginning or ending of the association and the effective time.
 
@@ -1319,7 +1319,7 @@ ICCBBA DIs: 2.16.840.1.113883.6.18.1.17 for Blood containers and 2.16.840.1.1138
 
 Example: |00643169001763{caret}{caret}2.51.1.1{caret}ISO|
 
-=== A.1.3 Application ACK Message
+=== A.1.3 Application Acknowledgement Message
 
 Table A.1.3-1: Communicate Device-Patient Association - Application Acknowledgement Message
 

--- a/CPs/cp_nn6.adoc
+++ b/CPs/cp_nn6.adoc
@@ -1475,6 +1475,42 @@ For example:
 
 |===
 
+|*A.1.3 Application ACK Message*, _add new section to define the application ack_:
+
+|=== 
+
+=== A.1.3 Application ACK Message
+
+Table A.1.3-1: Communicate Device-Patient Association - Application Acknowledgement Message
+
+|===
+| *Segments* | *Description* | *Usage*
+
+| MSH
+| Message Header - Defined in Appendix B.1
+| R
+
+| MSA
+| Message Acknowledgement - Defined in Appendix B.2
+| R
+
+| [{ ERR }]
+| Error - Defined in Appendix B.3.
+| C
+
+| [{ SFT }]
+| Software
+| X
+
+| [{ NTE }]
+| Notes and Comments
+| X
+
+|===
+
+
+|===
+
 |*A.2.1.6-2*, _remove unfinished sentence referencing UDI that should be included_
 
 |===

--- a/CPs/cp_nn6.adoc
+++ b/CPs/cp_nn6.adoc
@@ -796,7 +796,7 @@ If the checks are passed, the Manager establishes a record of the existence of t
 [.text-left]
 [underline]#Proposed Text:#
 [.text-left]
-After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. An optional application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager.  The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
+After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. If a positive commit-level acknowledgement is sent, an application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager.  The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
 
 If the checks are passed, the Manager establishes a record of the beginning or ending of the association and the effective time.
 
@@ -1475,7 +1475,7 @@ For example:
 
 |===
 
-|*A.1.3 Application ACK Message*, _add new section to define the application ack_:
+|*A.1.3 Application Acknowledgement Message*, _add new section to define the application ack_:
 
 |=== 
 

--- a/CPs/cp_nn6.adoc
+++ b/CPs/cp_nn6.adoc
@@ -1666,16 +1666,14 @@ Table A.2.3-1: Query Profile
 | ORU{caret}R01{caret}ORU_R01
 
 | Query Characteristics
-| Returns device-patient associations as constrained in the input parameters
+| Triggers a realtime subscription with filtering. No results are returned directly.
 
 | Purpose
-| Sends device-patient association records, filtered as defined in input parameters
+| Requests filtering of device-patient association records, as defined in input parameters
 
 | Response Characteristics
-| The response contains [DEV-51] device-patient association reports known to the Device-Patient Association Manager, filtered by the query parameters.
+| The response contains a commit-level ACK.
 
-| Based on Segment Pattern
-| R01 as constrained by transaction [PCD-01] (see details in PCD TF-2 3.10 and with the semantics of transaction [PCD-17] as in this profile.
 |===
 
 Table A.2.3-2: QBP{caret}Z66{caret}QBP{caret}QBP_Z66 Query Grammar - QBP Message Segments
@@ -1704,46 +1702,9 @@ Table A.2.3-2: QBP{caret}Z66{caret}QBP{caret}QBP_Z66 Query Grammar - QBP Message
 | 5.5.6
 |===
 
-For the segment pattern to be expected in the response to this query, see the definition of the ORU{caret}R01 Message Structure in PCD TF-2, which is a specialization of the ORU{caret}R01 Message Structure in HL7 Chapter 7, Section 7.3.1, ORU -- Unsolicited Observation Message (Event R01), as follows:
+A simple commit-level ACK is expected as response to this query, see section B.2 in IHE PCD TF VOL 2.
 
-Table A.2.3-3: Query Response Message Structure
-
-|===
-| *Segments* | *Description*
-
-| MSH
-| Message Header
-
-| [{ SFT }]
-| Software Segment
-
-| [UAC]
-| User Authentication Credential
-
-| PID
-| Patient Identification
-
-| [PV1]
-| Patient Visit Information (for room bed)
-
-| OBR
-| Observation Request
-
-| {
-| _One group for each device being associated with patient identified in the PID_
-
-| OBX
-| Observation Result
-
-| { PRT }
-| Participation -- _One PRT segment for device, one for responsible person_
-
-| }
-|
-|===
-
-Note that this segment pattern, unlike some segment patterns, is not introduced by any “header” type extra segments, but instead is a straight sequenced of repeats of [DEV-52] messages reporting current device-patient association events followed by ongoing real-time updates to device-patient association events, filtered according to optional query parameters. If the connection is lost, the manager must continue to try and establish a new connection to the consumer, always sending the current device-patient association events once the connection is re-established.
-
+The results of a successful query results in the manager sending all [DEV-52] messages reporting current device-patient association events followed by ongoing real-time updates to device-patient association events, all filtered according to optional query parameters. If the connection is lost, the manager must continue to try and establish a new connection to the consumer, always sending the current device-patient association events matching the filter once the connection is re-established.
 |===
 
 |*A.2.3.2-3 Identifiers for field, component, or subcomponent in QPD.3 User Parameters*, _update table to remove retrospective query capability by removing row for FLD PID 3.1 and last two rows for FLD OBR.7 and OBR.8_:

--- a/CPs/cp_nn6.adoc
+++ b/CPs/cp_nn6.adoc
@@ -258,7 +258,7 @@ image::original-actor-transaction-diagram.png[]
 |Actors|Transactions|Initiator or Responder|Optionality|Reference
 
 |Device-Patient Association Reporter
-|Communicate Device-Patient Association or Disassociation
+|Communicate Device-Patient Association
 |I
 |R
 |PCD TF-2 3.51
@@ -796,7 +796,8 @@ If the checks are passed, the Manager establishes a record of the existence of t
 [.text-left]
 [underline]#Proposed Text:#
 [.text-left]
-After these checks, the Manager logs the result and returns an appropriate positive or negative acknowledgement to the Reporter. The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
+After these checks, the Manager logs the result and returns an appropriate positive or negative commit-level acknowledgement to the Reporter. An optional application-level acknowledgment may be sent to the Reporter after the association or disassociation is validated at the Manager.  The system design must assure that errors are indicated to the appropriate human user(s) in an effective and timely manner so that action can be taken. In this case, a technical alert should be raised using the ACM profile, the details of this are out of scope for this document. 
+
 If the checks are passed, the Manager establishes a record of the beginning or ending of the association and the effective time.
 
 |===
@@ -816,7 +817,7 @@ If the checks are passed, the Manager establishes a record of the beginning or e
 [.text-left]
 == Report Device-Patient Association [DEV-52]
 
-Insert in Section 3 as new Section 3.52
+Insert in Section 3 of IHE TF Vol 2 as new Section 3.52
 
 === Scope
 
@@ -889,7 +890,7 @@ If a commit-level acknowledgement is received by the Manager, it logs the messag
 
 |===
 
-|*3.19 Query Device-Patient Associations [PCD-19]*, _rename to_: *Filter Device-Patient Associations [DEV-19]*
+|*3.19 Query Device-Patient Associations [PCD-19]*, _rename to_: *Filter Device-Patient Associations [DEV-19]* and add sentence "Insert in Section 3 of IHE TF Vol 2 as new Section 3.19" as top-level description.
 
 |=== 
 
@@ -1145,7 +1146,7 @@ For detailed semantics and the construction of the HL7 message structure and seg
 
 |=== 
 
-|*A.1 Report Device-Patient Association and Disassociation*, _change title to Communicate Device-Patient Association and update paragraph on line 703, to reference new transaction numbering and to explain the same message is used with minor differences for assertions vs reports_:
+|*A.1 Report Device-Patient Association and Disassociation*, _change title to Communicate Device-Patient Association and update paragraph on line 703, to reference new transaction numbering and to explain the same message is used with minor differences for assertions vs reports, also clearly reference IHE TF Vol 2 as to where this is inserted_:
 
 |=== 
 
@@ -1277,7 +1278,29 @@ Since this message is effectively an unsolicited observation report, the content
 [.text-left]
 [underline]#Proposed Text:#
 [.text-left]
-Since this message is effectively an unsolicited observation report, the contents of the MSH segment follow the specifications for [PCD-01] in PCD TF-2 Appendix B.1, except that MSH-21 is valued "IHE_DEV_051^IHE PCD\^1.3.6.1.4.1.19376.1.6.4.51.1^ISO" to identify it as a message representing a device-patient association.
+Since this message is effectively an unsolicited observation report, the contents of the MSH segment follow the specifications for [PCD-01] in PCD TF-2 Appendix B.1, except for the following changes:
+
+Table A.1.2.1-1: MSH Fields
+
+|===
+| *SEQ* | *DT* | *OPT*  | *Description*
+
+| 15
+| ID
+| R
+| Accept Acknowledgement Type - This must be set to "AL" and is returned on the same connection as the initiating message.
+
+| 16
+| ID
+| R
+| Application Acknowledgement Type – Set to AL, NE or ER. See IHE TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
+
+| 21
+| EI
+| R
+| Message Profile Identifier - Value set to "IHE_DEV_051^IHE PCD\^1.3.6.1.4.1.19376.1.6.4.51.1^ISO"
+
+|===
 
 |===
 

--- a/CPs/cp_nn6.adoc
+++ b/CPs/cp_nn6.adoc
@@ -817,7 +817,7 @@ If the checks are passed, the Manager establishes a record of the beginning or e
 [.text-left]
 == Report Device-Patient Association [DEV-52]
 
-Insert in Section 3 of IHE TF Vol 2 as new Section 3.52
+Insert in Section 3 of IHE PCD TF Vol 2 as new Section 3.52
 
 === Scope
 
@@ -890,7 +890,7 @@ If a commit-level acknowledgement is received by the Manager, it logs the messag
 
 |===
 
-|*3.19 Query Device-Patient Associations [PCD-19]*, _rename to_: *Filter Device-Patient Associations [DEV-19]* and add sentence "Insert in Section 3 of IHE TF Vol 2 as new Section 3.19" as top-level description.
+|*3.19 Query Device-Patient Associations [PCD-19]*, _rename to_: *Filter Device-Patient Associations [DEV-19]* and add sentence "Insert in Section 3 of IHE PCD TF Vol 2 as new Section 3.19" as top-level description.
 
 |=== 
 
@@ -1146,7 +1146,7 @@ For detailed semantics and the construction of the HL7 message structure and seg
 
 |=== 
 
-|*A.1 Report Device-Patient Association and Disassociation*, _change title to Communicate Device-Patient Association and update paragraph on line 703, to reference new transaction numbering and to explain the same message is used with minor differences for assertions vs reports, also clearly reference IHE TF Vol 2 as to where this is inserted_:
+|*A.1 Report Device-Patient Association and Disassociation*, _change title to Communicate Device-Patient Association and update paragraph on line 703, to reference new transaction numbering and to explain the same message is used with minor differences for assertions vs reports, also clearly reference IHE PCD TF Vol 2 as to where this is inserted_:
 
 |=== 
 
@@ -1293,7 +1293,7 @@ Table A.1.2.1-1: MSH Fields
 | 16
 | ID
 | R
-| Application Acknowledgement Type – Set to AL, NE or ER. See IHE TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
+| Application Acknowledgement Type – Set to AL, NE or ER. See IHE PCD TF Vol 2 Table 3.3.4.4.1-1 for description of possible values and their meaning.
 
 | 21
 | EI


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #54, #55

Ensure TF Vol 2 is referenced clearly.
Define MSH requirements by adding a table and defining MSH 15, 16 and 21. Reference table in TF Vol 2 for MSH 16 values.
Add message structure definition for application ack.
Specify DEV-19 ACK is simple, not a ORU_R01 with data.
